### PR TITLE
docs: add jq in tools to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ For this exercise, you will need :
 - [`kubectl`](https://kubernetes.io/docs/tasks/tools/)
 - [`kind`](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
 - [`helm`](https://helm.sh/docs/intro/install/)
+- [`jq`](https://stedolan.github.io/jq/)
 
 ## Step 2: Bootstrap the environment
 


### PR DESCRIPTION
Missing ```jq``` in step 8 and step 10